### PR TITLE
Fixed bug where project root with name charcoallog caused path errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
  - pip install -q -r requirements-dev.txt codecov
 script:
  - flake8
- - coverage run manage.py test -t ./
+ - coverage run manage.py test
  - coverage report
 after_success:
  - codecov


### PR DESCRIPTION
Solution from: https://stackoverflow.com/questions/21069880/running-django-tutorial-tests-fail-no-module-named-polls-tests)